### PR TITLE
Setting keyfile mode to 0600

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -95,7 +95,7 @@ class networkmanager::config (
       group   => 'root',
       recurse => true,
       purge   => $erase_unmanaged_keyfiles,
-      mode    => '0640';
- }
+      mode    => '0600';
+  }
 
 }


### PR DESCRIPTION
Thanks for all the effort putting in this module!

I had a small problem with unmanaged keyfiles having the wrong file mode, causing them not to be loaded on CentOS 8 and 9.

The file mode should be the same for managed keyfiles: `0600`.