### PR TITLE
impose limit of 3 to 15 characters on intreface names

### DIFF
--- a/manifests/ifc/bond.pp
+++ b/manifests/ifc/bond.pp
@@ -4,7 +4,7 @@
 define networkmanager::ifc::bond (
   Enum['absent', 'present'] $ensure = present,
   Enum['up', 'down']        $state = 'up',
-  String                    $id = $title, #connection name used during the start via nmcli
+  String[3, 15]             $id = $title, #connection name used during the start via nmcli
   String                    $type = 'bond',
   String                    $ifc_name = $title,
   Optional[String]          $master = undef,
@@ -23,11 +23,11 @@ define networkmanager::ifc::bond (
   Variant[Integer[-1, 2]]   $ipv6_privacy = 0,
   Boolean                   $ipv6_may_fail = true,
   Hash                      $additional_config = {}
-) 
+)
 {
   include networkmanager
   Class['networkmanager'] -> Networkmanager::Ifc::Bond[$title]
-  
+
   $ipv6_method_w = networkmanager::ipv6_disable_version($ipv6_method)
 
   if $master {
@@ -165,7 +165,7 @@ define networkmanager::ifc::bond (
     'require'           => File["/etc/NetworkManager/system-connections/${id}.nmconnection"]
   }
 
-  file { 
+  file {
      "/etc/NetworkManager/system-connections/${id}.nmconnection":
      ensure => $ensure,
      owner  => 'root',
@@ -176,7 +176,7 @@ define networkmanager::ifc::bond (
   }
 
   if $ensure == present {
-  
+
 #  @@exec { "activate ${id}":
 #     command => networkmanager::reload_connection($id, $state),
 #     provider    => 'shell',
@@ -187,7 +187,7 @@ define networkmanager::ifc::bond (
 #     tag => "nmactivate-2022b07${networkmanager::sys_id}";
 #  }
    networkmanager::activate_connection($id, $state)
-  
+
   }
 
   include networkmanager::reload

--- a/manifests/ifc/bond/slave.pp
+++ b/manifests/ifc/bond/slave.pp
@@ -4,7 +4,7 @@
 define networkmanager::ifc::bond::slave (
   Enum['absent', 'present'] $ensure = present,
   Enum['up', 'down']        $state = 'up',
-  String                    $id = $title, #connection name used during the start via nmcli
+  String[3, 15]             $id = $title, #connection name used during the start via nmcli
   String                    $type = 'ethernet',
   String                    $master = undef,
   String                    $slave_type = 'bond',
@@ -35,7 +35,7 @@ define networkmanager::ifc::bond::slave (
     'require'           => File["/etc/NetworkManager/system-connections/${id}.nmconnection"]
   }
 
-  file { 
+  file {
      "/etc/NetworkManager/system-connections/${id}.nmconnection":
      ensure => $ensure,
      owner  => 'root',
@@ -46,9 +46,9 @@ define networkmanager::ifc::bond::slave (
   }
 
   if $ensure == present {
-  
+
 #  @@exec { "activate ${id}":
-#     command => networkmanager::reload_connection($id, $state), 
+#     command => networkmanager::reload_connection($id, $state),
 #     provider    => 'shell',
 #     group => 'root',
 #     user => 'root',

--- a/manifests/ifc/bridge.pp
+++ b/manifests/ifc/bridge.pp
@@ -3,7 +3,7 @@
 # In the case when you want to specify special not listed parameters you can add them through additional_config hash and it will be merged with other parameters.
 define networkmanager::ifc::bridge (
   Enum['absent', 'present'] $ensure = present,
-  String                    $id = $title, #connection name used during the start via nmcli
+  String[3, 15              $id = $title, #connection name used during the start via nmcli
   String                    $type = 'bridge',
   String                    $ifc_name = $title,
   Enum['up', 'down']        $state = 'up',
@@ -24,11 +24,11 @@ define networkmanager::ifc::bridge (
   Variant[Integer[-1, 2]]   $ipv6_privacy = 0,
   Boolean                   $ipv6_may_fail = true,
   Hash                      $additional_config = {}
-) 
+)
 {
   include networkmanager
   Class['networkmanager'] -> Networkmanager::Ifc::Bridge[$title]
-  
+
   $ipv6_method_w = networkmanager::ipv6_disable_version($ipv6_method)
 
   if $master {
@@ -167,7 +167,7 @@ define networkmanager::ifc::bridge (
     'require'           => File["/etc/NetworkManager/system-connections/${id}.nmconnection"]
   }
 
-  file { 
+  file {
      "/etc/NetworkManager/system-connections/${id}.nmconnection":
      ensure => $ensure,
      owner  => 'root',
@@ -193,7 +193,7 @@ define networkmanager::ifc::bridge (
    networkmanager::activate_connection($id, $state)
 
   }
-  
+
   include networkmanager::reload
   Networkmanager::Ifc::Bridge[$title] ~> Class['networkmanager::reload']
 }

--- a/manifests/ifc/bridge/slave.pp
+++ b/manifests/ifc/bridge/slave.pp
@@ -4,7 +4,7 @@
 define networkmanager::ifc::bridge::slave (
   Enum['absent', 'present'] $ensure = present,
   Enum['up', 'down']        $state = 'up',
-  String                    $id = $title, #connection name used during the start via nmcli
+  String[3, 15]             $id = $title, #connection name used during the start via nmcli
   String                    $type = 'ethernet',
   String                    $master = undef,
   String                    $slave_type = 'bridge',
@@ -35,7 +35,7 @@ define networkmanager::ifc::bridge::slave (
     'require'           => File["/etc/NetworkManager/system-connections/${id}.nmconnection"]
   }
 
-  file { 
+  file {
      "/etc/NetworkManager/system-connections/${id}.nmconnection":
      ensure => $ensure,
      owner  => 'root',
@@ -43,12 +43,12 @@ define networkmanager::ifc::bridge::slave (
      replace   => true,
      mode   => '0600',
      content => hash2ini($keyfile_contents,$keyfile_settings);
-  } 
-  
+  }
+
   if $ensure == present {
 
 #  @@exec { "activate ${id}":
-#     command => networkmanager::reload_connection($id, $state), 
+#     command => networkmanager::reload_connection($id, $state),
 #     provider    => 'shell',
 #     group => 'root',
 #     user => 'root',

--- a/manifests/ifc/connection.pp
+++ b/manifests/ifc/connection.pp
@@ -3,7 +3,7 @@
 # In the case when you want to specify special not listed parameters you can add them through additional_config hash and it will be merged with other parameters.
 define networkmanager::ifc::connection(
   Enum['absent', 'present'] $ensure = present,
-  String                    $id = $title, #connection name used during the start via nmcli
+  String[3, 15]             $id = $title, #connection name used during the start via nmcli
   String                    $type = 'ethernet',
   Optional[String]          $interface_name = undef,
   Optional[Stdlib::MAC]     $mac_address = undef,

--- a/manifests/ifc/fallback.pp
+++ b/manifests/ifc/fallback.pp
@@ -2,7 +2,7 @@
 define networkmanager::ifc::fallback(
   Enum['absent', 'present'] $ensure = present,
   Enum['up', 'down']        $state = 'up',
-  String                    $id = $title,
+  String[3, 15]             $id = $title,
   Hash                      $config = {}, #pozaduje tento hash
 ) {
   include networkmanager
@@ -18,7 +18,7 @@ define networkmanager::ifc::fallback(
     'present' => 'file',
     default  => 'file'
   }
-    
+
   $needed_params = {
     'connection' => {
       'id'          => $id,

--- a/manifests/ifc/vlan.pp
+++ b/manifests/ifc/vlan.pp
@@ -3,7 +3,7 @@
 # In the case when you want to specify special not listed parameters you can add them through additional_config hash and it will be merged with other parameters.
 define networkmanager::ifc::vlan (
   Enum['absent', 'present'] $ensure = present,
-  String                    $id = $title, #connection name used during the start via nmcli
+  String[3, 15]             $id = $title, #connection name used during the start via nmcli
   String                    $type = 'vlan',
   Enum['up', 'down']        $state = 'up',
   Optional[String]          $master = undef,
@@ -57,7 +57,7 @@ define networkmanager::ifc::vlan (
     'require'           => File["/etc/NetworkManager/system-connections/${id}.nmconnection"]
   }
 
-  file { 
+  file {
      "/etc/NetworkManager/system-connections/${id}.nmconnection":
      ensure => $ensure,
      owner  => 'root',
@@ -68,9 +68,9 @@ define networkmanager::ifc::vlan (
   }
 
   if $ensure == present {
-  
+
 #  @@exec { "activate ${id}":
-#     command => networkmanager::reload_connection($id, $state), 
+#     command => networkmanager::reload_connection($id, $state),
 #     provider    => 'shell',
 #     group => 'root',
 #     user => 'root',
@@ -80,7 +80,7 @@ define networkmanager::ifc::vlan (
 #  }
 
    networkmanager::activate_connection($id, $state)
-  
+
   }
 
   include networkmanager::reload


### PR DESCRIPTION
Impose the limit of 3 to 15 characters on the connection/interface name to not to encounter 
`keyfile: load: "/etc/NetworkManager/system-connections/<long_connection_name>.nmconnection": failed to load connection: invalid connection: connection.interface-name: '<long_connection_name>': interface name is longer than 15 characters`
error