### PR TITLE
connection ID is not the interface name and does not need to be short

### DIFF
--- a/manifests/ifc/bond.pp
+++ b/manifests/ifc/bond.pp
@@ -4,7 +4,7 @@
 define networkmanager::ifc::bond (
   Enum['absent', 'present']                                     $ensure = present,
   Enum['up', 'down']                                            $state = 'up',
-  String[3, 15]                                                 $id = $title, #connection name used during the start via nmcli
+  String                                                        $id = $title, #connection name used during the start via nmcli
   String                                                        $type = 'bond',
   String[3, 15]                                                 $ifc_name = $title,
   Optional[String]                                              $master = undef,

--- a/manifests/ifc/bond/slave.pp
+++ b/manifests/ifc/bond/slave.pp
@@ -4,7 +4,7 @@
 define networkmanager::ifc::bond::slave (
   Enum['absent', 'present'] $ensure = present,
   Enum['up', 'down']        $state = 'up',
-  String[3, 15]             $id = $title, #connection name used during the start via nmcli
+  String                    $id = $title, #connection name used during the start via nmcli
   String                    $type = 'ethernet',
   String                    $master = undef,
   String                    $slave_type = 'bond',

--- a/manifests/ifc/bridge.pp
+++ b/manifests/ifc/bridge.pp
@@ -3,7 +3,7 @@
 # In the case when you want to specify special not listed parameters you can add them through additional_config hash and it will be merged with other parameters.
 define networkmanager::ifc::bridge (
   Enum['absent', 'present']                                     $ensure = present,
-  String[3, 15]                                                 $id = $title, #connection name used during the start via nmcli
+  String                                                        $id = $title, #connection name used during the start via nmcli
   String                                                        $type = 'bridge',
   String[3, 15]                                                 $ifc_name = $title,
   Enum['up', 'down']                                            $state = 'up',

--- a/manifests/ifc/bridge/slave.pp
+++ b/manifests/ifc/bridge/slave.pp
@@ -4,7 +4,7 @@
 define networkmanager::ifc::bridge::slave (
   Enum['absent', 'present'] $ensure = present,
   Enum['up', 'down']        $state = 'up',
-  String[3, 15]             $id = $title, #connection name used during the start via nmcli
+  String                    $id = $title, #connection name used during the start via nmcli
   String                    $type = 'ethernet',
   String                    $master = undef,
   String                    $slave_type = 'bridge',

--- a/manifests/ifc/connection.pp
+++ b/manifests/ifc/connection.pp
@@ -3,7 +3,7 @@
 # In the case when you want to specify special not listed parameters you can add them through additional_config hash and it will be merged with other parameters.
 define networkmanager::ifc::connection(
   Enum['absent', 'present']                                     $ensure = present,
-  String[3, 15]                                                 $id = $title, #connection name used during the start via nmcli
+  String                                                        $id = $title, #connection name used during the start via nmcli
   String                                                        $type = 'ethernet',
   Optional[String[3, 15]]                                       $interface_name = undef,
   Optional[Stdlib::MAC]                                         $mac_address = undef,

--- a/manifests/ifc/fallback.pp
+++ b/manifests/ifc/fallback.pp
@@ -2,7 +2,7 @@
 define networkmanager::ifc::fallback(
   Enum['absent', 'present'] $ensure = present,
   Enum['up', 'down']        $state = 'up',
-  String[3, 15]             $id = $title,
+  String                    $id = $title,
   Hash                      $config = {}, #pozaduje tento hash
 ) {
   include networkmanager

--- a/manifests/ifc/vlan.pp
+++ b/manifests/ifc/vlan.pp
@@ -3,7 +3,7 @@
 # In the case when you want to specify special not listed parameters you can add them through additional_config hash and it will be merged with other parameters.
 define networkmanager::ifc::vlan (
   Enum['absent', 'present'] $ensure = present,
-  String[3, 15]             $id = $title, #connection name used during the start via nmcli
+  String                    $id = $title, #connection name used during the start via nmcli
   String                    $type = 'vlan',
   Enum['up', 'down']        $state = 'up',
   Optional[String]          $master = undef,


### PR DESCRIPTION
Hi

Commit 223f783 did overshoot and causes a regression in our production Puppet code. Note that for network interface names there is a 15 char limit by the kernel, but not for the connection ID used by NetworkManager. It is often the same, but that is not a hard requirement and we normally tend to use more speaking names for the connection which makes the ID longer.

