### PR TITLE
Added the configurable maximal connection.id length

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You need a few additional libraries like hash2stuff.
 
 ### Beginning with networkmanager
 
-When you want to begin with NetworkManager, you need to be clever as devil, but 
+When you want to begin with NetworkManager, you need to be clever as devil, but
 our module will help you create keyfiles and push them inside that oven of hell.
 
 ## Usage
@@ -80,13 +80,18 @@ networkmanager::ifc::bond::slave { 'bondslaveens8':
   mac_address => 'MAC_ADDRESS',
   master  => 'bondmaster2',
 }
-  
+
 networkmanager::ifc::bond::slave { 'bondslaveens9':
   ensure => present,
   mac_address => 'MAC_ADDRESS',
   master  => 'bondmaster2',
 }
 ```
+
+## Connection id length
+The `connection.id` parametre is limited by deafult to 15 charactes, because is by deafult used also as the interface name.
+The interface name has upper limit of 15 characters set by kernel.
+You can override this limit by setting the $networkmanager::max_length_of_connection_id to the value you like but then you need to set, where applicable, the `connection.interface-name` to something what is less than 16 characters long.
 
 ## Contact
 

--- a/manifests/ifc/bond.pp
+++ b/manifests/ifc/bond.pp
@@ -4,7 +4,7 @@
 define networkmanager::ifc::bond (
   Enum['absent', 'present']                                     $ensure = present,
   Enum['up', 'down']                                            $state = 'up',
-  String[3, 15]                                                 $id = $title, #connection name used during the start via nmcli
+  String[3, $networkmanager::max_length_of_connection_id]       $id = $title, #connection name used during the start via nmcli
   String                                                        $type = 'bond',
   String[3, 15]                                                 $ifc_name = $title,
   Optional[String]                                              $master = undef,

--- a/manifests/ifc/bond/slave.pp
+++ b/manifests/ifc/bond/slave.pp
@@ -2,14 +2,14 @@
 # You can read parameters below.
 # In the case when you want to specify special not listed parameters you can add them through additional_config hash and it will be merged with other parameters.
 define networkmanager::ifc::bond::slave (
-  Enum['absent', 'present'] $ensure = present,
-  Enum['up', 'down']        $state = 'up',
-  String[3, 15]             $id = $title, #connection name used during the start via nmcli
-  String                    $type = 'ethernet',
-  String                    $master = undef,
-  String                    $slave_type = 'bond',
-  Stdlib::MAC               $mac_address = undef,
-  Hash                      $additional_config = {},
+  Enum['absent', 'present']                               $ensure = present,
+  Enum['up', 'down']                                      $state = 'up',
+  String[3, $networkmanager::max_length_of_connection_id] $id = $title, #connection name used during the start via nmcli
+  String                                                  $type = 'ethernet',
+  String                                                  $master = undef,
+  String                                                  $slave_type = 'bond',
+  Stdlib::MAC                                             $mac_address = undef,
+  Hash                                                    $additional_config = {},
 ){
   include networkmanager
   Class['networkmanager'] -> Networkmanager::Ifc::Bond::Slave[$title]

--- a/manifests/ifc/bridge.pp
+++ b/manifests/ifc/bridge.pp
@@ -3,7 +3,7 @@
 # In the case when you want to specify special not listed parameters you can add them through additional_config hash and it will be merged with other parameters.
 define networkmanager::ifc::bridge (
   Enum['absent', 'present']                                     $ensure = present,
-  String[3, 15]                                                 $id = $title, #connection name used during the start via nmcli
+  String[3, $networkmanager::max_length_of_connection_id]       $id = $title, #connection name used during the start via nmcli
   String                                                        $type = 'bridge',
   String[3, 15]                                                 $ifc_name = $title,
   Enum['up', 'down']                                            $state = 'up',

--- a/manifests/ifc/bridge/slave.pp
+++ b/manifests/ifc/bridge/slave.pp
@@ -2,14 +2,14 @@
 # You can read parameters below.
 # In the case when you want to specify special not listed parameters you can add them through additional_config hash and it will be merged with other parameters.
 define networkmanager::ifc::bridge::slave (
-  Enum['absent', 'present'] $ensure = present,
-  Enum['up', 'down']        $state = 'up',
-  String[3, 15]             $id = $title, #connection name used during the start via nmcli
-  String                    $type = 'ethernet',
-  String                    $master = undef,
-  String                    $slave_type = 'bridge',
-  Stdlib::MAC               $mac_address = undef,
-  Hash                      $additional_config = {},
+  Enum['absent', 'present']                               $ensure = present,
+  Enum['up', 'down']                                      $state = 'up',
+  String[3, $networkmanager::max_length_of_connection_id] $id = $title, #connection name used during the start via nmcli
+  String                                                  $type = 'ethernet',
+  String                                                  $master = undef,
+  String                                                  $slave_type = 'bridge',
+  Stdlib::MAC                                             $mac_address = undef,
+  Hash                                                    $additional_config = {},
 ){
   include networkmanager
   Class['networkmanager'] -> Networkmanager::Ifc::Bridge::Slave[$title]

--- a/manifests/ifc/connection.pp
+++ b/manifests/ifc/connection.pp
@@ -3,7 +3,7 @@
 # In the case when you want to specify special not listed parameters you can add them through additional_config hash and it will be merged with other parameters.
 define networkmanager::ifc::connection(
   Enum['absent', 'present']                                     $ensure = present,
-  String[3, 15]                                                 $id = $title, #connection name used during the start via nmcli
+  String[3, $networkmanager::max_length_of_connection_id]       $id = $title, #connection name used during the start via nmcli
   String                                                        $type = 'ethernet',
   Optional[String[3, 15]]                                       $interface_name = undef,
   Optional[Stdlib::MAC]                                         $mac_address = undef,

--- a/manifests/ifc/fallback.pp
+++ b/manifests/ifc/fallback.pp
@@ -1,9 +1,9 @@
 # This defined resource creates user defined keyfile
 define networkmanager::ifc::fallback(
-  Enum['absent', 'present'] $ensure = present,
-  Enum['up', 'down']        $state = 'up',
-  String[3, 15]             $id = $title,
-  Hash                      $config = {}, #pozaduje tento hash
+  Enum['absent', 'present']                               $ensure = present,
+  Enum['up', 'down']                                      $state = 'up',
+  String[3, $networkmanager::max_length_of_connection_id] $id = $title,
+  Hash                                                    $config = {}, #pozaduje tento hash
 ) {
   include networkmanager
   Networkmanager::Ifc::Fallback[$title] ~> Class['networkmanager']
@@ -54,6 +54,10 @@ define networkmanager::ifc::fallback(
 
 
   $params_e = deep_merge($needed_params, $config, $non_uuid_parents, $non_uuid_masters)
+
+  if 'connection' in $params_e and 'interface-name' in $params_e['connection'] and 15 < $params_e['connection']['interface-name'].length() {
+    fail("The 'connection.interface-name' for connection '${id}' can not be longer than 15 characters!")
+  }
 
   $keyfile_settings = {
     'path'              => $confilename,

--- a/manifests/ifc/vlan.pp
+++ b/manifests/ifc/vlan.pp
@@ -2,16 +2,16 @@
 # You can read parameters below.
 # In the case when you want to specify special not listed parameters you can add them through additional_config hash and it will be merged with other parameters.
 define networkmanager::ifc::vlan (
-  Enum['absent', 'present'] $ensure = present,
-  String[3, 15]             $id = $title, #connection name used during the start via nmcli
-  String                    $type = 'vlan',
-  Enum['up', 'down']        $state = 'up',
-  Optional[String]          $master = undef,
-  String                    $slave_type  = 'bridge',
-  String                    $vlan_id = undef,
-  Integer[0]                $vlan_flags = 1,
-  String                    $vlan_parent = undef,
-  Hash                      $additional_config = {},
+  Integer[1, 4096]                                        $vlan_id,
+  Enum['absent', 'present']                               $ensure = present,
+  String[3, $networkmanager::max_length_of_connection_id] $id = $title, #connection name used during the start via nmcli
+  String                                                  $type = 'vlan',
+  Enum['up', 'down']                                      $state = 'up',
+  Optional[String]                                        $master = undef,
+  String                                                  $slave_type  = 'bridge',
+  Integer[0]                                              $vlan_flags = 1,
+  String                                                  $vlan_parent = undef,
+  Hash                                                    $additional_config = {},
 ) {
   include networkmanager
   Class['networkmanager'] -> Networkmanager::Ifc::Vlan[$title]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class networkmanager (
   Variant[Boolean, Enum['stub'], Undef] $use_internal_resolv_conf = undef,
   Hash                                  $additional_config = {},
   Array[String]                         $plugins = ['keyfile'],
+  Integer[3]                            $max_length_of_connection_id = 15,
 )
 {
   $sys_id = [


### PR DESCRIPTION
Added the configuration parametre to allow longer `connection.id` names
`$networkmanager::max_length_of_connection_id`