### PR TITLE
the interface-name needs to be part of 'connection'

### DIFF
--- a/manifests/ifc/connection.pp
+++ b/manifests/ifc/connection.pp
@@ -82,7 +82,7 @@ define networkmanager::ifc::connection(
       id   => $id,
       uuid => $uuid,
       type => $type,
-    },
+    } + $interface_name_config,
   }
 
   if $mac_address {
@@ -160,7 +160,6 @@ define networkmanager::ifc::connection(
 
 
   $keyfile_contents = deep_merge(
-      $interface_name_config,
       $master_config,
       $connection_config,
       $mac_config,


### PR DESCRIPTION
With v1.0.0-rc1 I get an error when I try to select the interface using the interface name. Following resource definition

```
networkmanager::ifc::connection { 'upstream':
  interface_name => 'ens192',
  ipv4_method    => 'auto',
  ipv6_method    => 'disabled',
}
```
leads to
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, undefined method `each' for "ens192":String (file: /srv/puppet/code/nm_module/code/modules/networkmanager/manifests/connection_keyfile_manage.pp, line: 26, column: 18) (file: /srv/puppet/code/nm_module/code/modules/networkmanager/manifests/ifc/connection.pp, line: 181) on node lxdev07.psi.ch
```
which gets fixed with this PR.