### PR TITLE
no additional configuration when method disabled

### DIFF
--- a/manifests/ifc/connection.pp
+++ b/manifests/ifc/connection.pp
@@ -99,7 +99,10 @@ define networkmanager::ifc::connection(
 
   $ipv4_config = { ipv4 => { method => $ipv4_method } }
 
-  $ipv4_may_fail_config = { ipv4 => { may-fail => $ipv4_may_fail } }
+  $ipv4_may_fail_config = $ipv4_method ? {
+    'disabled' => {},
+    default    => { ipv4 => { may-fail => $ipv4_may_fail } },
+  }
 
   $ipv4_gw_config = $ipv4_gateway ? {
     undef   => {},
@@ -116,15 +119,24 @@ define networkmanager::ifc::connection(
     default => { ipv4 => { dns  => $ipv4_dns } },
   }
 
-  $ipv6_config = {
-    ipv6 => {
-      method        => $ipv6_method_w,
-      addr-gen-mode => $ipv6_addr_gen_mode,
-      ip6-privacy   => $ipv6_privacy,
+  if $ipv6_method_w in ['ignore', 'disabled'] {
+    $ipv6_config = {
+      ipv6 => {
+        method        => $ipv6_method_w,
+      }
     }
+    $ipv6_may_fail_config = {}
   }
-
-  $ipv6_may_fail_config = { ipv6 => { may-fail => $ipv6_may_fail } }
+  else {
+    $ipv6_config = {
+      ipv6 => {
+        method        => $ipv6_method_w,
+        addr-gen-mode => $ipv6_addr_gen_mode,
+        ip6-privacy   => $ipv6_privacy,
+      }
+    }
+    $ipv6_may_fail_config = { ipv6 => { may-fail => $ipv6_may_fail } }
+  }
 
   $ipv6_gw_config = $ipv6_gateway ? {
     undef   => {},


### PR DESCRIPTION
With v1.0.0-rc1 I get some unnecessary configuration if I disable an IP family.

Resource definition:
```
networkmanager::ifc::connection { 'sniffer':
  mac_address => '00:50:56:9d:24:78',
  ipv4_method => 'disabled',
  ipv6_method => 'disabled',
}
```
gets now following diff compared to commit a538619:
```
@@ -10,6 +10,10 @@
 
 [ipv4]
 method=disabled
+may-fail=true
 
 [ipv6]
 method=disabled
+addr-gen-mode=0
+ip6-privacy=0
+may-fail=true

```
which is not so nice as no specific detail configuration is needed or has any effect with `disabled`.
With this PR there is no diff any more for this case.
