### PR TITLE
with "connection" subkey the $interface_name_config needs to go to the deep merge

### DIFF
--- a/manifests/ifc/connection.pp
+++ b/manifests/ifc/connection.pp
@@ -82,7 +82,7 @@ define networkmanager::ifc::connection(
       id   => $id,
       uuid => $uuid,
       type => $type,
-    } + $interface_name_config,
+    },
   }
 
   if $mac_address {
@@ -172,6 +172,7 @@ define networkmanager::ifc::connection(
 
 
   $keyfile_contents = deep_merge(
+      $interface_name_config,
       $master_config,
       $connection_config,
       $mac_config,


### PR DESCRIPTION
The interface name PRs #20 and #18 are incompatible:

diff:
```
 id=upstream
 uuid=bef03518-7544-58dd-af69-d8560d06434e
 type=ethernet
-interface-name=ens192
+connection={"interface-name"=>"ens192"}
 
 [ipv4]
 method=auto
```

This PR rectifies it:
```
 [connection]
+interface-name=ens192
 id=upstream
 uuid=bef03518-7544-58dd-af69-d8560d06434e
 type=ethernet
-connection={"interface-name"=>"ens192"}
```