### PR TITLE
no additional ipv4/6 configuration when disabled

### DIFF
--- a/functions/prepare_ipv4_config.pp
+++ b/functions/prepare_ipv4_config.pp
@@ -1,0 +1,49 @@
+# Prepares the "ipv4" configuration section
+# Parametres:
+#   $ipv4_method = what method to use to get an IPv4 address
+#   $ipv4_address = semicolon separated list of the IPv4 addresses to assign to the interface in format 127.0.0.1/8
+#   $ipv4_gateway = the IPv4 gateway for the connection
+#   $ipv4_dns = semicolon seperated list of the dns servers for the interface
+#   $ipv4_may_fail = is it ok that the IPv4 config fails?
+
+function networkmanager::prepare_ipv4_config (
+  Enum['auto', 'dhcp', 'manual', 'disabled', 'link-local'] $ipv4_method,
+  Optional[Networkmanager::IPV4_CIDR]                      $ipv4_address,
+  Optional[Stdlib::IP::Address::V4::Nosubnet]              $ipv4_gateway,
+  Optional[Networkmanager::DNS_IPV4]                       $ipv4_dns,
+  Boolean                                                  $ipv4_may_fail,
+) >> Hash {
+
+  $ipv4_base_config = { ipv4 => { method => $ipv4_method } }
+
+  if $ipv4_method != 'disabled' {
+    $ipv4_may_fail_config = { ipv4 => { may-fail => $ipv4_may_fail } }
+
+    $ipv4_gw_config = $ipv4_gateway ? {
+      undef   => {},
+      default => { ipv4 => { gateway => $ipv4_gateway } },
+    }
+
+    $ipv4_address_config = $ipv4_address ? {
+      undef   => {},
+      default => { ipv4 => { address  => $ipv4_address } },
+    }
+
+    $ipv4_dns_config = $ipv4_dns ? {
+      undef   => {},
+      default => { ipv4 => { dns  => $ipv4_dns } },
+    }
+
+    $ipv4_detail_config = deep_merge(
+        $ipv4_may_fail_config,
+        $ipv4_gw_config,
+        $ipv4_address_config,
+        $ipv4_dns_config,
+      )
+  }
+  else {
+    $ipv4_detail_config = {}
+  }
+
+  deep_merge($ipv4_base_config, $ipv4_detail_config)
+}

--- a/functions/prepare_ipv6_config.pp
+++ b/functions/prepare_ipv6_config.pp
@@ -1,0 +1,86 @@
+# Prepares the "ipv6" configuration section
+# Parametres:
+#   $ipv6_method = what method to use to get an ipv6 address
+#   $ipv6_address = semicolon separated list of the ipv6 addresses to assign to the interface in format aa::bb:cc/64
+#   $ipv6_gateway = the ipv6 gateway for the connection
+#   $ipv6_dns = semicolon seperated list of the dns servers for the interface
+#   $ipv6_dhcp_duid = IPv6 DHCP DUID 'auto' value generates it with module from mac of the interface
+#   $ipv6_addr_gen_mode = IPv6 method for generating of automatic interface address
+#   $ipv6_privacy = should be the generated automatic address more private
+#   $ipv6_may_fail = is it ok that the ipv6 config fails?
+
+function networkmanager::prepare_ipv6_config (
+  Enum['auto','dhcp','manual','ignore','link-local','disabled'] $ipv6_method,
+  Optional[Stdlib::IP::Address::V6::CIDR]                       $ipv6_address,
+  Optional[Stdlib::IP::Address::V6::Nosubnet]                   $ipv6_gateway,
+  Optional[Networkmanager::DNS_IPV6]                            $ipv6_dns,
+  Optional[String]                                              $ipv6_dhcp_duid,
+  Integer[0, 3]                                                 $ipv6_addr_gen_mode,
+  Integer[-1, 2]                                                $ipv6_privacy,
+  Boolean                                                       $ipv6_may_fail,
+) >> Hash {
+
+  $ipv6_method_w = networkmanager::ipv6_disable_version($ipv6_method)
+
+  if $ipv6_method_w in ['ignore', 'disabled'] {
+    $ipv6_base_config = {
+      ipv6 => {
+        method => $ipv6_method_w,
+      }
+    }
+    $ipv6_detail_config = {}
+  }
+  else {
+    $ipv6_base_config = {
+      ipv6 => {
+        method        => $ipv6_method_w,
+        addr-gen-mode => $ipv6_addr_gen_mode,
+        ip6-privacy   => $ipv6_privacy,
+        may-fail      => $ipv6_may_fail,
+      }
+    }
+
+    $ipv6_gw_config = $ipv6_gateway ? {
+      undef   => {},
+      default => { ipv6 => { gateway => $ipv6_gateway } },
+    }
+
+    $ipv6_address_config = $ipv6_address ? {
+      undef   => {},
+      default => { ipv6 => { address  => $ipv6_address } },
+    }
+
+    $ipv6_dns_config = $ipv6_dns ? {
+      undef   => {},
+      default => { ipv6 => { dns  => $ipv6_dns } },
+    }
+
+    $ipv6_dhcp_duid_w = networkmanager::get_ipv6_duid($ipv6_dhcp_duid, $mac_address)
+
+    if $ipv6_dhcp_duid_w == undef
+      and $ipv6_method_w in ['auto', 'dhcp']
+      and 'present' == $ensure
+      and 'up' == $state {
+        fail("IPv6 method for connection '${id}' is '${ipv6_method_w}' but no \$ipv6_dhcp_duid was supplied.")
+    }
+    elsif $ipv6_method_w in ['auto', 'dhcp'] and 'up' == $state {
+      $ipv6_duid_config = {
+        ipv6 => {
+          dhcp-duid => $ipv6_dhcp_duid_w,
+        }
+      }
+    }
+    else {
+      $ipv6_duid_config = {}
+    }
+
+    $ipv6_detail_config = deep_merge(
+        $ipv6_gw_config,
+        $ipv6_address_config,
+        $ipv6_dns_config,
+        $ipv6_duid_config
+      )
+  }
+
+  deep_merge($ipv6_base_config, $ipv6_detail_config)
+}

--- a/functions/prepare_ipv6_config.pp
+++ b/functions/prepare_ipv6_config.pp
@@ -4,20 +4,22 @@
 #   $ipv6_address = semicolon separated list of the ipv6 addresses to assign to the interface in format aa::bb:cc/64
 #   $ipv6_gateway = the ipv6 gateway for the connection
 #   $ipv6_dns = semicolon seperated list of the dns servers for the interface
-#   $ipv6_dhcp_duid = IPv6 DHCP DUID 'auto' value generates it with module from mac of the interface
 #   $ipv6_addr_gen_mode = IPv6 method for generating of automatic interface address
 #   $ipv6_privacy = should be the generated automatic address more private
 #   $ipv6_may_fail = is it ok that the ipv6 config fails?
+#   $ipv6_dhcp_duid = IPv6 DHCP DUID 'auto' value generates it with module from mac of the interface
+#   $mac_address = the mac of the interface for the connection
 
 function networkmanager::prepare_ipv6_config (
   Enum['auto','dhcp','manual','ignore','link-local','disabled'] $ipv6_method,
   Optional[Stdlib::IP::Address::V6::CIDR]                       $ipv6_address,
   Optional[Stdlib::IP::Address::V6::Nosubnet]                   $ipv6_gateway,
   Optional[Networkmanager::DNS_IPV6]                            $ipv6_dns,
-  Optional[String]                                              $ipv6_dhcp_duid,
   Integer[0, 3]                                                 $ipv6_addr_gen_mode,
   Integer[-1, 2]                                                $ipv6_privacy,
   Boolean                                                       $ipv6_may_fail,
+  Optional[String]                                              $ipv6_dhcp_duid,
+  Optional[Stdlib::MAC]                                         $mac_address,
 ) >> Hash {
 
   $ipv6_method_w = networkmanager::ipv6_disable_version($ipv6_method)

--- a/functions/validate_ifc_name_and_mac.pp
+++ b/functions/validate_ifc_name_and_mac.pp
@@ -3,7 +3,7 @@
 #   $caller = the puppet name of the resource which called this function (for sensible error line)
 #   $caller_title = the instance of the resouce which alled the fumction (for sensible error line)
 #   $interface_mac = the connection interface mac address
-#   $ine4terface_name = the connection interface name
+#   $interface_name = the connection interface name
 
 function networkmanager::validate_ifc_name_and_mac (
   String                        $caller,

--- a/manifests/ifc/bond.pp
+++ b/manifests/ifc/bond.pp
@@ -11,7 +11,7 @@
 #   $ipv4_address = semicolon separated list of the IPv4 addresses to assign to the interface in format 127.0.0.1/8
 #   $ipv4_gateway = the IPv4 gateway for the connection
 #   $ipv4_dns = semicolon seperated list of the dns servers for the interface
-#   $ipv4_may_fail = is it ik that the IPv4 config fails? DEFAULT: true
+#   $ipv4_may_fail = is it ok that the IPv4 config fails? DEFAULT: true
 #   $ipv6_method = what method to use to get an ipv6 address DEFAULT: 'auto'
 #   $ipv6_address = semicolon separated list of the ipv6 addresses to assign to the interface in format aa::bb:cc/64
 #   $ipv6_gateway = the ipv6 gateway for the connection
@@ -19,7 +19,7 @@
 #   $ipv6_dhcp_duid = IPv6 DHCP DUID 'auto' value generates it with module from mac of the interface
 #   $ipv6_addr_gen_mode = IPv6 method for generating of automatic interface address
 #   $ipv6_privacy = should be the generated automatic address more private
-#   $ipv6_may_fail = is it ik that the ipv6 config fails? DEFAULT: true
+#   $ipv6_may_fail = is it ok that the ipv6 config fails? DEFAULT: true
 #   $addtional_config = Other not covered configuration
 #     In the case when you want to specify special not listed parameters you can add them through
 #     $additional_config hash and it will be merged with other parameters.
@@ -75,8 +75,6 @@ define networkmanager::ifc::bond (
   include networkmanager
   Class['networkmanager'] -> Networkmanager::Ifc::Bond[$title]
 
-  $ipv6_method_w = networkmanager::ipv6_disable_version($ipv6_method)
-
   $uuid = networkmanager::connection_uuid($id)
 
   if $master {
@@ -96,83 +94,29 @@ define networkmanager::ifc::bond (
     bond => { mode => $bond_mode, }
   }
 
-  $ipv6_dhcp_duid_w = networkmanager::get_ipv6_duid($ipv6_dhcp_duid, $mac_address)
-
-  $ipv4_config = { ipv4 => { method => $ipv4_method } }
-
-  $ipv4_may_fail_config = { ipv4 => { may-fail => $ipv4_may_fail } }
-
-  $ipv4_gw_config = $ipv4_gateway ? {
-    undef   => {},
-    default => { ipv4 => { gateway => $ipv4_gateway } },
-  }
-
-  $ipv4_address_config = $ipv4_address ? {
-    undef   => {},
-    default => { ipv4 => { address  => $ipv4_address } },
-  }
-
-  $ipv4_dns_config = $ipv4_dns ? {
-    undef   => {},
-    default => { ipv4 => { dns  => $ipv4_dns } },
-  }
-
-  $ipv6_config = {
-    ipv6 => {
-      method        => $ipv6_method_w,
-      addr-gen-mode => $ipv6_addr_gen_mode,
-      ip6-privacy   => $ipv6_privacy,
-    }
-  }
-
-  $ipv6_may_fail_config = { ipv6 => { may-fail => $ipv6_may_fail } }
-
-  $ipv6_gw_config = $ipv6_gateway ? {
-    undef   => {},
-    default => { ipv6 => { gateway => $ipv6_gateway } },
-  }
-
-  $ipv6_address_config = $ipv6_address ? {
-    undef   => {},
-    default => { ipv6 => { address  => $ipv6_address } },
-  }
-
-  $ipv6_dns_config = $ipv6_dns ? {
-    undef   => {},
-    default => { ipv6 => { dns  => $ipv6_dns } },
-  }
-
-  if $ipv6_dhcp_duid_w == undef
-    and $ipv6_method_w in ['auto', 'dhcp']
-    and 'present' == $ensure
-    and 'up' == $state {
-      fail("IPv6 method for connection '${id}' is '${ipv6_method_w}' but no \$ipv6_dhcp_duid was supplied.")
-  }
-  elsif $ipv6_method_w in ['auto', 'dhcp'] and 'up' == $state {
-    $ipv6_duid_config = {
-      ipv6 => {
-        dhcp-duid     => $ipv6_dhcp_duid_w,
-      }
-    }
-  }
-  else {
-    $ipv6_duid_config = {}
-  }
+  $ipv4_config = networkmanager::prepare_ipv4_config(
+      $ipv4_method,
+      $ipv4_address,
+      $ipv4_gateway,
+      $ipv4_dns,
+      $ipv4_may_fail
+    )
+  $ipv6_config = networkmanager::prepare_ipv6_config(
+      $ipv6_method,
+      $ipv6_address,
+      $ipv6_gateway,
+      $ipv6_dns,
+      $ipv6_dhcp_duid,
+      $ipv6_addr_gen_mode,
+      $ipv6_privacy,
+      $ipv6_may_fail
+    )
 
   $keyfile_contents = deep_merge(
       $master_config,
       $connection_config,
       $ipv4_config,
-      $ipv4_may_fail_config,
-      $ipv4_gw_config,
-      $ipv4_address_config,
-      $ipv4_dns_config,
       $ipv6_config,
-      $ipv6_may_fail_config,
-      $ipv6_gw_config,
-      $ipv6_address_config,
-      $ipv6_dns_config,
-      $ipv6_duid_config,
       $additional_config
     )
 

--- a/manifests/ifc/bond.pp
+++ b/manifests/ifc/bond.pp
@@ -106,10 +106,11 @@ define networkmanager::ifc::bond (
       $ipv6_address,
       $ipv6_gateway,
       $ipv6_dns,
-      $ipv6_dhcp_duid,
       $ipv6_addr_gen_mode,
       $ipv6_privacy,
-      $ipv6_may_fail
+      $ipv6_may_fail,
+      $ipv6_dhcp_duid,
+      $mac_address
     )
 
   $keyfile_contents = deep_merge(

--- a/manifests/ifc/bridge.pp
+++ b/manifests/ifc/bridge.pp
@@ -12,7 +12,7 @@
 #   $ipv4_address = semicolon separated list of the IPv4 addresses to assign to the interface in format 127.0.0.1/8
 #   $ipv4_gateway = the IPv4 gateway for the connection
 #   $ipv4_dns = semicolon seperated list of the dns servers for the interface
-#   $ipv4_may_fail = is it ik that the IPv4 config fails? DEFAULT: true
+#   $ipv4_may_fail = is it ok that the IPv4 config fails? DEFAULT: true
 #   $ipv6_method = what method to use to get an ipv6 address DEFAULT: 'auto'
 #   $ipv6_address = semicolon separated list of the ipv6 addresses to assign to the interface in format aa::bb:cc/64
 #   $ipv6_gateway = the ipv6 gateway for the connection
@@ -20,7 +20,7 @@
 #   $ipv6_dhcp_duid = IPv6 DHCP DUID 'auto' value generates it with module from mac of the interface
 #   $ipv6_addr_gen_mode = IPv6 method for generating of automatic interface address
 #   $ipv6_privacy = should be the generated automatic address more private
-#   $ipv6_may_fail = is it ik that the ipv6 config fails? DEFAULT: true
+#   $ipv6_may_fail = is it ok that the ipv6 config fails? DEFAULT: true
 #   $addtional_config = Other not covered configuration
 #     In the case when you want to specify special not listed parameters you can add them through
 #     $additional_config hash and it will be merged with other parameters.
@@ -58,8 +58,6 @@ define networkmanager::ifc::bridge (
     fail("The connection \$id must have length from 3 to ${networkmanager::max_length_of_connection_id} characters")
   }
 
-  $ipv6_method_w = networkmanager::ipv6_disable_version($ipv6_method)
-
   $uuid = networkmanager::connection_uuid($id)
 
   if $master {
@@ -82,83 +80,30 @@ define networkmanager::ifc::bridge (
     }
   }
 
-  $ipv6_dhcp_duid_w = networkmanager::get_ipv6_duid($ipv6_dhcp_duid, $mac_address)
+  $ipv4_config = networkmanager::prepare_ipv4_config(
+      $ipv4_method,
+      $ipv4_address,
+      $ipv4_gateway,
+      $ipv4_dns,
+      $ipv4_may_fail
+    )
 
-  $ipv4_config = { ipv4 => { method => $ipv4_method } }
-
-  $ipv4_may_fail_config = { ipv4 => { may-fail => $ipv4_may_fail } }
-
-  $ipv4_gw_config = $ipv4_gateway ? {
-    undef   => {},
-    default => { ipv4 => { gateway => $ipv4_gateway } },
-  }
-
-  $ipv4_address_config = $ipv4_address ? {
-    undef   => {},
-    default => { ipv4 => { address  => $ipv4_address } },
-  }
-
-  $ipv4_dns_config = $ipv4_dns ? {
-    undef   => {},
-    default => { ipv4 => { dns  => $ipv4_dns } },
-  }
-
-  $ipv6_config = {
-    ipv6 => {
-      method        => $ipv6_method_w,
-      addr-gen-mode => $ipv6_addr_gen_mode,
-      ip6-privacy   => $ipv6_privacy,
-    }
-  }
-
-  $ipv6_may_fail_config = { ipv6 => { may-fail => $ipv6_may_fail } }
-
-  $ipv6_gw_config = $ipv6_gateway ? {
-    undef   => {},
-    default => { ipv6 => { gateway => $ipv6_gateway } },
-  }
-
-  $ipv6_address_config = $ipv6_address ? {
-    undef   => {},
-    default => { ipv6 => { address  => $ipv6_address } },
-  }
-
-  $ipv6_dns_config = $ipv6_dns ? {
-    undef   => {},
-    default => { ipv6 => { dns  => $ipv6_dns } },
-  }
-
-  if $ipv6_dhcp_duid_w == undef
-    and $ipv6_method_w in ['auto', 'dhcp']
-    and 'present' == $ensure
-    and 'up' == $state {
-      fail("IPv6 method for connection '${id}' is '${ipv6_method_w}' but no \$ipv6_dhcp_duid was supplied.")
-  }
-  elsif $ipv6_method_w in ['auto', 'dhcp'] and 'up' == $state {
-    $ipv6_duid_config = {
-      ipv6 => {
-        dhcp-duid => $ipv6_dhcp_duid_w,
-      }
-    }
-  }
-  else {
-    $ipv6_duid_config = {}
-  }
+  $ipv6_config = networkmanager::prepare_ipv6_config(
+      $ipv6_method,
+      $ipv6_address,
+      $ipv6_gateway,
+      $ipv6_dns,
+      $ipv6_dhcp_duid,
+      $ipv6_addr_gen_mode,
+      $ipv6_privacy,
+      $ipv6_may_fail
+    )
 
   $keyfile_contents = deep_merge(
       $master_config,
       $connection_config,
       $ipv4_config,
-      $ipv4_may_fail_config,
-      $ipv4_gw_config,
-      $ipv4_address_config,
-      $ipv4_address_config,
       $ipv6_config,
-      $ipv6_may_fail_config,
-      $ipv6_gw_config,
-      $ipv6_address_config,
-      $ipv6_dns_config,
-      $ipv6_duid_config,
       $additional_config
     )
 

--- a/manifests/ifc/bridge.pp
+++ b/manifests/ifc/bridge.pp
@@ -93,10 +93,11 @@ define networkmanager::ifc::bridge (
       $ipv6_address,
       $ipv6_gateway,
       $ipv6_dns,
-      $ipv6_dhcp_duid,
       $ipv6_addr_gen_mode,
       $ipv6_privacy,
-      $ipv6_may_fail
+      $ipv6_may_fail,
+      $ipv6_dhcp_duid,
+      $mac_address
     )
 
   $keyfile_contents = deep_merge(

--- a/manifests/ifc/connection.pp
+++ b/manifests/ifc/connection.pp
@@ -11,7 +11,7 @@
 #   $ipv4_address = semicolon separated list of the IPv4 addresses to assign to the interface in format 127.0.0.1/8
 #   $ipv4_gateway = the IPv4 gateway for the connection
 #   $ipv4_dns = semicolon seperated list of the dns servers for the interface
-#   $ipv4_may_fail = is it ik that the IPv4 config fails? DEFAULT: true
+#   $ipv4_may_fail = is it ok that the IPv4 config fails? DEFAULT: true
 #   $ipv6_method = what method to use to get an ipv6 address DEFAULT: 'auto'
 #   $ipv6_address = semicolon separated list of the ipv6 addresses to assign to the interface in format aa::bb:cc/64
 #   $ipv6_gateway = the ipv6 gateway for the connection
@@ -19,7 +19,7 @@
 #   $ipv6_dhcp_duid = IPv6 DHCP DUID 'auto' value generates it with module from mac of the interface
 #   $ipv6_addr_gen_mode = IPv6 method for generating of automatic interface address
 #   $ipv6_privacy = should be the generated automatic address more private
-#   $ipv6_may_fail = is it ik that the ipv6 config fails? DEFAULT: true
+#   $ipv6_may_fail = is it ok that the ipv6 config fails? DEFAULT: true
 #   $addtional_config = Other not covered configuration
 #     In the case when you want to specify special not listed parameters you can add them through
 #     $additional_config hash and it will be merged with other parameters.
@@ -61,8 +61,6 @@ define networkmanager::ifc::connection(
 
   $uuid = networkmanager::connection_uuid($id)
 
-  $ipv6_method_w = networkmanager::ipv6_disable_version($ipv6_method)
-
   if $interface_name {
     $interface_name_config = { connection => { interface-name => $interface_name } }
   }
@@ -92,69 +90,24 @@ define networkmanager::ifc::connection(
     $mac_config = {}
   }
 
-  $ipv6_dhcp_duid_w = networkmanager::get_ipv6_duid($ipv6_dhcp_duid, $mac_address)
+  $ipv4_config = networkmanager::prepare_ipv4_config(
+      $ipv4_method,
+      $ipv4_address,
+      $ipv4_gateway,
+      $ipv4_dns,
+      $ipv4_may_fail
+    )
 
-  $ipv4_config = { ipv4 => { method => $ipv4_method } }
-
-  $ipv4_may_fail_config = { ipv4 => { may-fail => $ipv4_may_fail } }
-
-  $ipv4_gw_config = $ipv4_gateway ? {
-    undef   => {},
-    default => { ipv4 => { gateway => $ipv4_gateway } },
-  }
-
-  $ipv4_address_config = $ipv4_address ? {
-    undef   => {},
-    default => { ipv4 => { address  => $ipv4_address } },
-  }
-
-  $ipv4_dns_config = $ipv4_dns ? {
-    undef   => {},
-    default => { ipv4 => { dns  => $ipv4_dns } },
-  }
-
-  $ipv6_config = {
-    ipv6 => {
-      method        => $ipv6_method_w,
-      addr-gen-mode => $ipv6_addr_gen_mode,
-      ip6-privacy   => $ipv6_privacy,
-    }
-  }
-
-  $ipv6_may_fail_config = { ipv6 => { may-fail => $ipv6_may_fail } }
-
-  $ipv6_gw_config = $ipv6_gateway ? {
-    undef   => {},
-    default => { ipv6 => { gateway => $ipv6_gateway } },
-  }
-
-  $ipv6_address_config = $ipv6_address ? {
-    undef   => {},
-    default => { ipv6 => { address  => $ipv6_address } },
-  }
-
-  $ipv6_dns_config = $ipv6_dns ? {
-    undef   => {},
-    default => { ipv6 => { dns  => $ipv6_dns } },
-  }
-
-  if $ipv6_dhcp_duid_w == undef
-    and $ipv6_method_w in ['auto', 'dhcp']
-    and 'present' == $ensure
-    and 'up' == $state {
-      fail("IPv6 method for connection '${id}' is '${ipv6_method_w}' but no \$ipv6_dhcp_duid was supplied.")
-  }
-  elsif $ipv6_method_w in ['auto', 'dhcp'] and 'up' == $state {
-    $ipv6_duid_config = {
-      ipv6 => {
-        dhcp-duid => $ipv6_dhcp_duid_w,
-      }
-    }
-  }
-  else {
-    $ipv6_duid_config = {}
-  }
-
+  $ipv6_config = networkmanager::prepare_ipv6_config(
+      $ipv6_method,
+      $ipv6_address,
+      $ipv6_gateway,
+      $ipv6_dns,
+      $ipv6_dhcp_duid,
+      $ipv6_addr_gen_mode,
+      $ipv6_privacy,
+      $ipv6_may_fail
+    )
 
   $keyfile_contents = deep_merge(
       $interface_name_config,
@@ -162,16 +115,7 @@ define networkmanager::ifc::connection(
       $connection_config,
       $mac_config,
       $ipv4_config,
-      $ipv4_may_fail_config,
-      $ipv4_gw_config,
-      $ipv4_address_config,
-      $ipv4_dns_config,
       $ipv6_config,
-      $ipv6_may_fail_config,
-      $ipv6_gw_config,
-      $ipv6_address_config,
-      $ipv6_dns_config,
-      $ipv6_duid_config,
       $additional_config
     )
 

--- a/manifests/ifc/connection.pp
+++ b/manifests/ifc/connection.pp
@@ -103,10 +103,11 @@ define networkmanager::ifc::connection(
       $ipv6_address,
       $ipv6_gateway,
       $ipv6_dns,
-      $ipv6_dhcp_duid,
       $ipv6_addr_gen_mode,
       $ipv6_privacy,
-      $ipv6_may_fail
+      $ipv6_may_fail,
+      $ipv6_dhcp_duid,
+      $mac_address
     )
 
   $keyfile_contents = deep_merge(


### PR DESCRIPTION
This PR refactors the `ipv4` and `ipv6` configuration hash generation into a own function each.

In these functions additional configuration is only attached if the respective family is enabled.

On my test node (using only connection resources :-( ) I get now no additional configuration except that IPv4 and IPv6 are disabled. 

```
[root@lxdev08 ~]# cat /etc/NetworkManager/system-connections/sniffer.nmconnection 
# THIS FILE IS CONTROLLED BY PUPPET

[connection]
interface-name=ens224
id=sniffer
uuid=ddc5b71b-d603-5c1e-a8c7-03b11d9b00c1
type=ethernet

[ipv4]
method=disabled

[ipv6]
method=disabled
[root@lxdev08 ~]# 
```