### PR TITLE
Fix ipv6.duid configuration

### DIFF
--- a/manifests/ifc/connection.pp
+++ b/manifests/ifc/connection.pp
@@ -144,7 +144,7 @@ define networkmanager::ifc::connection(
     and 'up' == $state {
       fail("IPv6 method for connection '${id}' is '${ipv6_method_w}' but no \$ipv6_dhcp_duid was supplied.")
   }
-  elsif $ipv6_method_w in ['auto', 'dhcp'] and 'up' == $state {
+  elsif $ipv6_method_w in ['auto', 'dhcp'] and 'up' == $state and $ipv6_dhcp_duid_w != undef {
     $ipv6_duid_config = {
       ipv6 => {
         dhcp-duid => $ipv6_dhcp_duid_w,


### PR DESCRIPTION
There is a chance that the variable ipv6_dhcp_duid_w  is not defined. If it is undefined, the config ipv6.duid should not be written (as it is optional anyway)
Without this fix one would run into a problem with this newly introduced check: https://github.com/jednoprsak/PuppetNetworkManagerModule/pull/25